### PR TITLE
Fix site manifest cross-origin

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -61,7 +61,11 @@ export const links: LinksFunction = () => {
 			href: '/favicons/favicon-32x32.png',
 		},
 		{ rel: 'apple-touch-icon', href: '/favicons/apple-touch-icon.png' },
-		{ rel: 'manifest', href: '/site.webmanifest' },
+		{
+			rel: 'manifest',
+			href: '/site.webmanifest',
+			crossOrigin: 'use-credentials',
+		},
 		{ rel: 'icon', type: 'image/svg+xml', href: '/favicons/favicon.svg' },
 		{ rel: 'stylesheet', href: fontStylestylesheetUrl },
 		{ rel: 'stylesheet', href: tailwindStylesheetUrl },

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -46,7 +46,6 @@ import { getFlashSession } from './utils/flash-session.server.ts'
 import { useToast } from './utils/useToast.tsx'
 import { Toaster } from './components/ui/toaster.tsx'
 
-// @ts-ignore is there a bug with LinksFunction type?
 export const links: LinksFunction = () => {
 	return [
 		// Preload svg sprite as a resource to avoid render blocking
@@ -66,7 +65,7 @@ export const links: LinksFunction = () => {
 			rel: 'manifest',
 			href: '/site.webmanifest',
 			crossOrigin: 'use-credentials',
-		},
+		} as const, // needed to make typescript happy
 		{ rel: 'icon', type: 'image/svg+xml', href: '/favicons/favicon.svg' },
 		{ rel: 'stylesheet', href: fontStylestylesheetUrl },
 		{ rel: 'stylesheet', href: tailwindStylesheetUrl },

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -46,6 +46,7 @@ import { getFlashSession } from './utils/flash-session.server.ts'
 import { useToast } from './utils/useToast.tsx'
 import { Toaster } from './components/ui/toaster.tsx'
 
+// @ts-ignore is there a bug with LinksFunction type?
 export const links: LinksFunction = () => {
 	return [
 		// Preload svg sprite as a resource to avoid render blocking


### PR DESCRIPTION
Site manifest is triggering a second SSL handshake:

![image](https://github.com/manawiki/MUDchat/assets/84349818/08dcc805-47ce-4ddf-9d0f-39ced8f6b328)

Cause:

> If the manifest requires credentials to fetch, the [crossorigin](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin) attribute must be set to use-credentials, even if the manifest file is in the same origin as the current page.

https://developer.mozilla.org/en-US/docs/Web/Manifest#deploying_a_manifest

Post-fix:

![image](https://github.com/manawiki/MUDchat/assets/84349818/bde261e6-9139-47ae-8ec4-9b79ad769f70)

